### PR TITLE
Add genetic maps to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ COPY phase GLIMPSE/phase/
 COPY split_reference GLIMPSE/split_reference/
 COPY versions GLIMPSE/versions/
 COPY makefile GLIMPSE/makefile
+COPY maps /usr/share/glimpse/maps/
 
 # remove editing leftovers
 RUN find GLIMPSE -name ".*.cpp" -delete


### PR DESCRIPTION
Having the maps in the image avoids the need to copy them